### PR TITLE
PS/2キーボード制御修正

### DIFF
--- a/source/pld/src/peripheral/keyboard/eseps2.v
+++ b/source/pld/src/peripheral/keyboard/eseps2.v
@@ -77,7 +77,6 @@ module eseps2 #(
 	reg				ff_e1_detect;
 	reg				ff_ps2_send;
 	reg				ff_ps2_virtual_shift;
-	reg				ff_e0_detect_dl;
 	reg				ff_error;
 	reg				ff_no_send;
 	reg		[1:0]	ff_ps2_clk_count;
@@ -823,7 +822,6 @@ module eseps2 #(
 			ff_ps2_virtual_shift	<= 1'b0;
 			ff_func_keys			<= 6'b000000;
 			ff_matupd_ppi_c			<= 1'b0;
-			ff_e0_detect_dl			<= 1'b0;
 		end
 		else begin
 			if( ff_matupd_state == MATUPD_ST_RESET ) begin
@@ -836,9 +834,8 @@ module eseps2 #(
 			else if( ff_matupd_state == MATUPD_ST_IDLE ) begin
 				ff_matupd_we	<= 1'b0;
 				if( clkena && (ff_ps2_state == PS2_ST_RCV_SCAN) && (ff_ps2_sub_state == PS2_SUB_WAIT) && !ff_e1_detect ) begin
-					ff_matupd_state <= MATUPD_ST_KEYMAP_READ1;
+					ff_matupd_state <= Kmap == 1'b1 ? MATUPD_ST_KEYMAP_READ1 : MATUPD_ST_KEYMAP_READ2;
 					ff_key_unpress	<= ff_f0_detect;
-					ff_e0_detect_dl <= ff_e0_detect;
 					ff_keymap_index <= { ~Kmap, ~ff_shift_key & Kmap, ff_e0_detect, ff_ps2_rcv_dat };
 					ff_matupd_ppi_c <= 1'b0;
 				end
@@ -856,6 +853,7 @@ module eseps2 #(
 			else if( ff_matupd_state == MATUPD_ST_MATRIX_READ1_REQ ) begin
 				if( w_keymap_dat == 8'hFF ) begin
 					ff_matupd_state <= MATUPD_ST_KEYMAP_READ2;
+					ff_keymap_index[9] <= ff_shift_key;
 				end
 				else begin
 					ff_matupd_state <= MATUPD_ST_MATRIX_READ1_RES;
@@ -870,7 +868,7 @@ module eseps2 #(
 				ff_matupd_state <= MATUPD_ST_KEYMAP_READ2;
 				ff_matupd_we	<= 1'b1;
 				ff_matupd_keys	<= w_matrix | w_mask;
-				ff_keymap_index <= { ~Kmap, ff_shift_key & Kmap, ff_e0_detect_dl, ff_ps2_rcv_dat };
+				ff_keymap_index[9] <= ff_shift_key;
 			end
 			//	ここからは、現在押された/放されたキーに対応する MSXマトリクスのビットを適切な値で上書きする
 			else if( ff_matupd_state == MATUPD_ST_KEYMAP_READ2 ) begin


### PR DESCRIPTION
- 日本語キーボード時はIDLEからKEYMAP_READ2に遷移するように変更
- MATRIX_READ1_REQからKEYMAP_READ2に遷移する時にkeymapアドレス9に反転ではないシフト状態を設定するように変更